### PR TITLE
Fix a EXC_BAD_ACCESS in validator for some string values

### DIFF
--- a/FXModelValidation/validators/FXModelValidator.m
+++ b/FXModelValidation/validators/FXModelValidator.m
@@ -97,7 +97,7 @@ static NSDictionary *FXFormBuiltInValidators;
 	return  (
 		value == nil || [value isKindOfClass:[NSNull class]] ||
 		(([value isKindOfClass:[NSArray class]] || [value isKindOfClass:[NSDictionary class]] || [value isKindOfClass:[NSSet class]] || [value isKindOfClass:[NSOrderedSet class]]) && [value count] < 1) ||
-		([value isKindOfClass:[NSString class]] && [value length] < 1)
+		([value isKindOfClass:[NSString class]] && [(NSString *)value length] < 1)
 	);
 }
 


### PR DESCRIPTION
I was finding that sometimes -length, when called on an uncast (id) who is truly an NSString, returned a pointer which is then compared to an int, causing the EXC_BAD_ACCESS crash. This explicit casting should help. Just before it, there is some logic determining if something is a collection class and then calling -count; I fear the same thing might occur there but I don't want to make that logic more verbose than it is and I'm not sure it experiences the same problem. Probably worth a look.